### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -14,6 +14,11 @@ import whichcraft
 import lib.errors
 import bin.unzip_gecko
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 # clone link
 CLONE = "https://github.com/ekultek/zeus-scanner.git"
 # current version <major.minor.commit.patch ID>


### PR DESCRIPTION
__raw_input()__ is called on lines 276 and 283 but it was removed from Python 3 in favor of __input()__.